### PR TITLE
Adds single file inference endpoint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,7 @@ jobs:
           tox -- \
             tests/api/test_app.py::test_local_start_api_and_healthy \
             tests/api/test_routers.py::test_router_marker \
+            tests/api/test_routers.py::test_inference_single_file_upload_marker \
             tests/api/test_routers.py::test_inference_marker
 
       - name: Tear down services

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
             tests/api/test_app.py::test_local_start_api_and_healthy \
             tests/api/test_routers.py::test_router_marker \
             tests/api/test_routers.py::test_inference_single_file_upload_marker \
-            tests/api/test_routers.py::test_inference_marker
+            tests/api/test_routers.py::test_inference_on_folder_marker
 
       - name: Tear down services
         working-directory: ${{ github.workspace }}

--- a/src/api/app/main.py
+++ b/src/api/app/main.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 
 from fastapi import FastAPI, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from .routers import marker, sparrow
 
@@ -21,6 +21,12 @@ app = FastAPI(swagger_ui_parameters={"tryItOutEnabled": True})
 
 app.include_router(sparrow.router)
 app.include_router(marker.router)
+
+
+@app.get("/", include_in_schema=False)
+async def root() -> RedirectResponse:
+    """Redirect localhost:<PORT> to Swagger at localhost:<PORT>/docs."""
+    return RedirectResponse(url="/docs")
 
 
 @app.get("/")

--- a/src/api/app/main.py
+++ b/src/api/app/main.py
@@ -17,7 +17,7 @@ logging.basicConfig(
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-app = FastAPI()
+app = FastAPI(swagger_ui_parameters={"tryItOutEnabled": True})
 
 app.include_router(sparrow.router)
 app.include_router(marker.router)

--- a/src/api/app/routers/marker.py
+++ b/src/api/app/routers/marker.py
@@ -12,8 +12,6 @@ from dotenv import load_dotenv
 from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
 
-from api.app.util import check_data_folder
-
 load_dotenv()
 
 if os.getenv("MARKER_API_PORT"):
@@ -26,6 +24,30 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 router = APIRouter()
+
+
+def check_data_folder() -> Path | str:
+    """Check if Docker or local deployment and adjust DATA_FOLDER accordingly."""
+    # Detect if in Docker container
+    is_docker = Path("/.dockerenv").exists()
+
+    logger.info("HOST_DATA_FOLDER: %s", str(os.environ.get("HOST_DATA_FOLDER")))
+
+    if is_docker:
+        logger.info("Detected running inside Docker container.")
+        DATA_FOLDER = str(os.environ.get("CONTAINER_DATA_FOLDER"))
+    elif not is_docker:
+        logger.info("Detected running on host machine.")
+        DATA_FOLDER = str(os.environ.get("HOST_DATA_FOLDER"))
+
+    if Path(DATA_FOLDER).exists():
+        logger.info("DATA_FOLDER: %s", DATA_FOLDER)
+    else:
+        e = f"{Path(DATA_FOLDER)!s} not found or does not exist."
+        logger.exception(NotADirectoryError(e))
+        raise NotADirectoryError(e)
+
+    return DATA_FOLDER
 
 
 @router.get("/marker/health")

--- a/src/api/app/routers/marker.py
+++ b/src/api/app/routers/marker.py
@@ -81,7 +81,7 @@ async def inference_single_doc(file_upload: Annotated[UploadFile, File()] = None
     logger.info("post request - headers: %s", headers)
 
     # nb: timeout currently arbitrarily one hour
-    response = requests.post(url=url, files=file, headers=headers, timeout=60 * 60) # noqa: ASYNC210
+    response = requests.post(url=url, files=file, headers=headers, timeout=60 * 60)  # noqa: ASYNC210
 
     t2 = datetime.datetime.now(datetime.UTC)
     td = t2 - t1

--- a/src/api/app/routers/marker.py
+++ b/src/api/app/routers/marker.py
@@ -5,11 +5,11 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import requests
 from dotenv import load_dotenv
-from fastapi import APIRouter, status
+from fastapi import APIRouter, File, UploadFile, status
 from fastapi.responses import JSONResponse
 
 load_dotenv()
@@ -51,7 +51,7 @@ def check_data_folder() -> Path | str:
 
 
 @router.get("/marker/health")
-async def health() -> dict[str, Any]:
+async def healthcheck() -> dict[str, Any]:
     """Test aliveness endpoint for Marker."""
     logger.info("[GET] /marker/health")
     url = f"http://marker:{MARKER_API_PORT}/health"
@@ -60,10 +60,45 @@ async def health() -> dict[str, Any]:
     return json.loads(response.content.decode("utf-8"))
 
 
-@router.post("/marker/inference")
-async def inference() -> JSONResponse:
-    """Runs Marker OCR inference."""
-    logger.info("[POST] /marker/inference")
+@router.post("/marker/inference_single", status_code=status.HTTP_200_OK)
+async def inference_single_doc(file_upload: Annotated[UploadFile, File()] = None) -> JSONResponse:
+    """
+    Runs Marker OCR inference on a single document.
+
+    UploadFile object forwarded onto inference API.
+    """
+    logger.info("[POST] /marker/inference_single_doc")
+    url = f"http://marker:{MARKER_API_PORT}/inference"
+
+    t1 = datetime.datetime.now(datetime.UTC)
+
+    file_bytes = await file_upload.read()
+    file = {"file": (file_upload.filename, file_bytes, file_upload.content_type)}
+    headers = {"accept": "application/json"}
+
+    logger.info("post request - url: %s", url)
+    logger.info("post request - file: %s", file)
+    logger.info("post request - headers: %s", headers)
+
+    # nb: timeout currently arbitrarily one hour
+    response = requests.post(url=url, files=file, headers=headers, timeout=60 * 60) # noqa: ASYNC210
+
+    t2 = datetime.datetime.now(datetime.UTC)
+    td = t2 - t1
+
+    response_json = {
+        "filename": str(file_upload.filename),
+        "duration_in_second": td.total_seconds(),
+        "ocr-result": response.text,
+    }
+
+    return JSONResponse(status_code=status.HTTP_200_OK, content=response_json)
+
+
+@router.post("/marker/inference_folder")
+async def inference_folder() -> JSONResponse:
+    """Runs Marker OCR inference on multiple documents in a folder."""
+    logger.info("[POST] /marker/inference_folder")
     url = f"http://marker:{MARKER_API_PORT}/inference"
     # URL of marker service
     # TODO(tom): configure with env var (e.g. so can set 127.0.0.1 if running on host)

--- a/src/api/app/routers/sparrow.py
+++ b/src/api/app/routers/sparrow.py
@@ -3,12 +3,13 @@
 import datetime
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
 import requests
 from fastapi import APIRouter
+
+from api.app.util import check_data_folder
 
 # Creating an object
 logger = logging.getLogger()
@@ -37,21 +38,7 @@ async def inference() -> dict:
     logger.info("[POST] /sparrow-ocr/inference")
     url = "http://sparrow:8001/api/v1/sparrow-ocr/inference"  # fwd request to sparrow service
 
-    logger.info("HOST_DATA_FOLDER: %s", str(os.environ.get("HOST_DATA_FOLDER")))
-
-    if is_docker:
-        logger.info("Detected running inside Docker container.")
-        DATA_FOLDER = str(os.environ.get("CONTAINER_DATA_FOLDER"))
-    elif not is_docker:
-        logger.info("Detected running on host machine.")
-        DATA_FOLDER = str(os.environ.get("HOST_DATA_FOLDER"))
-
-    if Path(DATA_FOLDER).exists():
-        logger.info("DATA_FOLDER: %s", DATA_FOLDER)
-    else:
-        e = f"{Path(DATA_FOLDER)!s} not found or does not exist."
-        logger.exception(NotADirectoryError(e))
-        raise NotADirectoryError(e)
+    DATA_FOLDER = check_data_folder()
 
     filenames = [str(f.name) for f in Path(DATA_FOLDER).iterdir() if f.suffix == ".pdf"]
     logger.info("Filenames in %s: %s", DATA_FOLDER, filenames)

--- a/src/api/app/routers/sparrow.py
+++ b/src/api/app/routers/sparrow.py
@@ -3,13 +3,12 @@
 import datetime
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
 import requests
 from fastapi import APIRouter
-
-from api.app.util import check_data_folder
 
 # Creating an object
 logger = logging.getLogger()
@@ -19,6 +18,30 @@ logger.setLevel(logging.DEBUG)
 is_docker = Path("/.dockerenv").exists()
 
 router = APIRouter()
+
+
+def check_data_folder() -> Path | str:
+    """Check if Docker or local deployment and adjust DATA_FOLDER accordingly."""
+    # Detect if in Docker container
+    is_docker = Path("/.dockerenv").exists()
+
+    logger.info("HOST_DATA_FOLDER: %s", str(os.environ.get("HOST_DATA_FOLDER")))
+
+    if is_docker:
+        logger.info("Detected running inside Docker container.")
+        DATA_FOLDER = str(os.environ.get("CONTAINER_DATA_FOLDER"))
+    elif not is_docker:
+        logger.info("Detected running on host machine.")
+        DATA_FOLDER = str(os.environ.get("HOST_DATA_FOLDER"))
+
+    if Path(DATA_FOLDER).exists():
+        logger.info("DATA_FOLDER: %s", DATA_FOLDER)
+    else:
+        e = f"{Path(DATA_FOLDER)!s} not found or does not exist."
+        logger.exception(NotADirectoryError(e))
+        raise NotADirectoryError(e)
+
+    return DATA_FOLDER
 
 
 # nb: sparrow hard codes API port to 8001

--- a/src/api/app/routers/sparrow.py
+++ b/src/api/app/routers/sparrow.py
@@ -92,8 +92,8 @@ async def inference_single_doc(file_upload: Annotated[UploadFile, File()] = None
 
 
 @router.post("/sparrow-ocr/inference")
-async def inference() -> dict:
-    """Runs Sparrow OCR inference."""
+async def inference_folder() -> dict:
+    """Runs Sparrow OCR inference on multiple documents in a folder."""
     logger.info("[POST] /sparrow-ocr/inference")
     url = "http://sparrow:8001/api/v1/sparrow-ocr/inference"  # fwd request to sparrow service
 

--- a/src/api/app/routers/sparrow.py
+++ b/src/api/app/routers/sparrow.py
@@ -5,10 +5,11 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import requests
-from fastapi import APIRouter
+from fastapi import APIRouter, File, UploadFile, status
+from fastapi.responses import JSONResponse
 
 # Creating an object
 logger = logging.getLogger()
@@ -46,13 +47,48 @@ def check_data_folder() -> Path | str:
 
 # nb: sparrow hard codes API port to 8001
 @router.get("/sparrow-ocr")
-async def hello() -> dict[str, Any]:
+async def healthcheck() -> dict[str, Any]:
     """Test aliveness endpoint for Sparrow."""
     logger.info("[GET] /sparrow")
     url = "http://sparrow:8001"
     response = requests.get(url, timeout=5)  # noqa: ASYNC210
 
     return json.loads(response.content.decode("utf-8"))
+
+
+@router.post("/sparrow-ocr/inference_single", status_code=status.HTTP_200_OK)
+async def inference_single_doc(file_upload: Annotated[UploadFile, File()] = None) -> JSONResponse:
+    """
+    Runs Sparrow OCR inference on a single document.
+
+    UploadFile object forwarded onto inference API.
+    """
+    logger.info("[POST] /sparrow-ocr/inference_single_doc")
+    url = "http://sparrow:8001/api/v1/sparrow-ocr/inference"  # fwd request to sparrow service
+
+    t1 = datetime.datetime.now(datetime.UTC)
+
+    file_bytes = await file_upload.read()
+    file = {"file": (file_upload.filename, file_bytes, file_upload.content_type)}
+    headers = {"accept": "application/json"}
+
+    logger.info("post request - url: %s", url)
+    logger.info("post request - file: %s", file)
+    logger.info("post request - headers: %s", headers)
+
+    # nb: timeout currently arbitrarily one hour
+    response = requests.post(url=url, files=file, headers=headers, timeout=60 * 60) # noqa: ASYNC210
+
+    t2 = datetime.datetime.now(datetime.UTC)
+    td = t2 - t1
+
+    response_json = {
+        "filename": str(file_upload.filename),
+        "duration_in_second": td.total_seconds(),
+        "ocr-result": response.text,
+    }
+
+    return JSONResponse(status_code=status.HTTP_200_OK, content=response_json)
 
 
 @router.post("/sparrow-ocr/inference")

--- a/src/api/app/routers/sparrow.py
+++ b/src/api/app/routers/sparrow.py
@@ -77,7 +77,7 @@ async def inference_single_doc(file_upload: Annotated[UploadFile, File()] = None
     logger.info("post request - headers: %s", headers)
 
     # nb: timeout currently arbitrarily one hour
-    response = requests.post(url=url, files=file, headers=headers, timeout=60 * 60) # noqa: ASYNC210
+    response = requests.post(url=url, files=file, headers=headers, timeout=60 * 60)  # noqa: ASYNC210
 
     t2 = datetime.datetime.now(datetime.UTC)
     td = t2 - t1

--- a/src/api/app/util.py
+++ b/src/api/app/util.py
@@ -1,0 +1,36 @@
+"""Utility functions for OCR API."""
+
+import logging
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+def check_data_folder() -> Path | str:
+    """Check if Docker or local deployment and adjust DATA_FOLDER accordingly."""
+    # Detect if in Docker container
+    is_docker = Path("/.dockerenv").exists()
+
+    logger.info("HOST_DATA_FOLDER: %s", str(os.environ.get("HOST_DATA_FOLDER")))
+
+    if is_docker:
+        logger.info("Detected running inside Docker container.")
+        DATA_FOLDER = str(os.environ.get("CONTAINER_DATA_FOLDER"))
+    elif not is_docker:
+        logger.info("Detected running on host machine.")
+        DATA_FOLDER = str(os.environ.get("HOST_DATA_FOLDER"))
+
+    if Path(DATA_FOLDER).exists():
+        logger.info("DATA_FOLDER: %s", DATA_FOLDER)
+    else:
+        e = f"{Path(DATA_FOLDER)!s} not found or does not exist."
+        logger.exception(NotADirectoryError(e))
+        raise NotADirectoryError(e)
+
+    return DATA_FOLDER

--- a/src/ocr/marker/api.py
+++ b/src/ocr/marker/api.py
@@ -30,7 +30,9 @@ except Exception:
     except Exception:
         logger.exception("Marker imports not possible.")
 
-app = FastAPI()
+app = FastAPI(swagger_ui_parameters={"tryItOutEnabled": True})
+
+
 
 
 @app.get("/health", status_code=status.HTTP_200_OK)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import time
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -29,6 +30,12 @@ class StartApiError(Exception):
     def __init__(self) -> None:
         """Initialize the exception with a message."""
         super().__init__("Cannot find main.py to start API.")
+
+
+@pytest.fixture(scope="module")
+def single_pdf_filepath() -> Path:
+    """Returns filepath of single synthetic PDF file."""
+    return Path("tests/data/single_synthetic_doc/ms-note-one-page.pdf")
 
 
 @pytest.fixture(scope="module")

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -12,7 +12,7 @@ def test_local_start_api_and_healthy(ocr_forwarding_api_port: str) -> None:
     """Test API app comes up and healthcheck returns 200."""
     response = requests.get(f"http://127.0.0.1:{ocr_forwarding_api_port}/", timeout=5)
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"service": "pyonb-ocr-api", "status": "healthy"}
+    assert response.url == f"http://127.0.0.1:{ocr_forwarding_api_port}/docs"
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_routers.py
+++ b/tests/api/test_routers.py
@@ -45,6 +45,23 @@ def test_inference_single_file_upload_marker(ocr_forwarding_api_port: str, singl
     assert response.json()["filename"] in single_pdf_filename
 
 
+@pytest.mark.asyncio
+def test_inference_single_file_upload_sparrow(ocr_forwarding_api_port: str, single_pdf_filepath: Path) -> None:
+    """Test PDF conversion using sparrow with single file endpoint."""
+    url = f"http://127.0.0.1:{ocr_forwarding_api_port}/sparrow-ocr/inference_single"
+
+    single_pdf_filename = single_pdf_filepath.name
+
+    with Path.open(single_pdf_filepath, "rb") as f:
+        files = {"file_upload": (single_pdf_filename, f, "application/pdf")}
+        headers = {"accept": "application/json"}
+        response = requests.post(url, files=files, headers=headers, timeout=60 * 60)
+
+    assert response.status_code == requests.codes.ok
+    assert response.json()["duration_in_second"] > 0
+    assert response.json()["filename"] in single_pdf_filename
+
+
 def test_inference_on_folder_marker(ocr_forwarding_api_port: str) -> None:
     """
     Test PDF conversion using marker pointed at a folder of files.

--- a/tests/api/test_routers.py
+++ b/tests/api/test_routers.py
@@ -25,9 +25,9 @@ def test_router_sparrow(ocr_forwarding_api_port: str) -> None:
     assert response.json() == {"message": "Sparrow OCR API"}
 
 
-def test_inference_marker(ocr_forwarding_api_port: str) -> None:
+def test_inference_on_folder_marker(ocr_forwarding_api_port: str) -> None:
     """
-    Test PDF conversion using marker.
+    Test PDF conversion using marker pointed at a folder of files.
 
     Note:
     - may take ~minutes to perform inference
@@ -45,9 +45,9 @@ def test_inference_marker(ocr_forwarding_api_port: str) -> None:
     }
 
 
-def test_inference_sparrow(ocr_forwarding_api_port: str) -> None:
+def test_inference_on_folder_sparrow(ocr_forwarding_api_port: str) -> None:
     """
-    Test PDF conversion using sparrow.
+    Test PDF conversion using sparrow pointed at a folder of files.
 
     Note:
     - may take ~minutes to perform inference

--- a/tests/api/test_routers.py
+++ b/tests/api/test_routers.py
@@ -34,7 +34,7 @@ def test_inference_marker(ocr_forwarding_api_port: str) -> None:
     - four possible files assertion depending on whether testing single_synthetic_doc or multiple_synthetic_docs folder
 
     """
-    response = requests.post(f"http://127.0.0.1:{ocr_forwarding_api_port}/marker/inference", timeout=60 * 60)
+    response = requests.post(f"http://127.0.0.1:{ocr_forwarding_api_port}/marker/inference_folder", timeout=60 * 60)
     assert response.status_code == requests.codes.ok
     assert response.json()["total_duration_in_second"] > 0
     assert response.json()["result"][0]["filename"] in {
@@ -54,7 +54,7 @@ def test_inference_sparrow(ocr_forwarding_api_port: str) -> None:
     - four possible files assertion depending on whether testing single_synthetic_doc or multiple_synthetic_docs folder
 
     """
-    response = requests.post(f"http://127.0.0.1:{ocr_forwarding_api_port}/sparrow-ocr/inference", timeout=60 * 60)
+    response = requests.post(f"http://127.0.0.1:{ocr_forwarding_api_port}/sparrow-ocr/inference_folder", timeout=60 * 60)
     assert response.status_code == requests.codes.ok
     assert response.json()["total_duration_in_second"] > 0
     assert response.json()["result"][0]["filename"] in {

--- a/tests/api/test_routers.py
+++ b/tests/api/test_routers.py
@@ -54,7 +54,9 @@ def test_inference_sparrow(ocr_forwarding_api_port: str) -> None:
     - four possible files assertion depending on whether testing single_synthetic_doc or multiple_synthetic_docs folder
 
     """
-    response = requests.post(f"http://127.0.0.1:{ocr_forwarding_api_port}/sparrow-ocr/inference_folder", timeout=60 * 60)
+    response = requests.post(
+        f"http://127.0.0.1:{ocr_forwarding_api_port}/sparrow-ocr/inference_folder", timeout=60 * 60
+    )
     assert response.status_code == requests.codes.ok
     assert response.json()["total_duration_in_second"] > 0
     assert response.json()["result"][0]["filename"] in {


### PR DESCRIPTION
Resolves #24 

Currently, pyonb operates on a folder containing PDF files set by the ENV variable `HOST_DATA_FOLDER`. This is fine, but it would be cleaner to upload files to the API, particularly for the Airflow DAG.

This PR:
- adds `inference_single_doc()` endpoints to marker and sparrow
- renames the old inference endpoints to: `inference_folder()`
- unrelated QoL improvement: sets Swagger Docs as default landing page when developer navigates to localhost endpoints

**TODO:**
- [x] add unit tests for inference_single_doc().